### PR TITLE
Fix a css problem of missing }

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,6 +21,7 @@ body
 .container
 {
     width: 100%;
+}
 h1
 {
     margin: 20px 0px;


### PR DESCRIPTION
Fix a missing closing brace in the `style.css` file.

* Add missing closing brace `}` for `.container` class in `style.css` file.

